### PR TITLE
Allow setting the toolchain prefix for cross-compilation

### DIFF
--- a/gcc-arm-none-eabi.toolchain.cmake
+++ b/gcc-arm-none-eabi.toolchain.cmake
@@ -1,5 +1,8 @@
 # Toolchain for gcc-arm-none-eabi
-set(PREFIX /usr/bin/arm-none-eabi-)
+if(NOT DEFINED PREFIX)
+	message(STATUS "PREFIX variable is not defined. Assuming \"/usr/bin/arm-none-eabi-\"")
+	set(PREFIX /usr/bin/arm-none-eabi-)
+endif()
 set(CMAKE_C_COMPILER ${PREFIX}gcc)
 set(CMAKE_CXX_COMPILER ${PREFIX}g++)
 set(CMAKE_ASM_COMPILER ${PREFIX}gcc)


### PR DESCRIPTION
This allows build hosts like macOS to use a cross-compiler sitting in ~/Downloads to cross-compile pinata sources.

For example, if you have an ARM cross compiler downloaded in

	~/Downloads/arm-gnu-toolchain-13.3.rel1-darwin-arm64-arm-none-eabi

You should configure cmake with

	cmake -DPREFIX=~/Downloads/arm-gnu-toolchain-13.3.rel1-darwin-arm64-arm-none-eabi/bin/arm-none-eabi- -DCMAKE_TOOLCHAIN_FILE=./gcc-arm-none-eabi.toolchain.cmake ..