### PR TITLE
Fix function declaration in ecc.h

### DIFF
--- a/src/ecc/ecc.h
+++ b/src/ecc/ecc.h
@@ -16,7 +16,7 @@
 #define CURVE25519_POINT_COMPRESSED_BYTES 32
 #define PROJ_COORD_RE_RAND_TOTAL_RAND_BYTES (4 * 256)
 
-void ecsm();
+void ecsm(uint8_t *rxBuffer);
 
 
 #endif


### PR DESCRIPTION
In main.c, the function `ecsm` is invoked with a `uint8_t*` buffer. It is also defined as such in the ecc.c file. Only in the header file is it defined without taking arguments.

Newer ARM GNU compiler toolchains will point this out, but older versions did not.